### PR TITLE
Accurately Display Citadel as a Dependency.

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -14,7 +14,7 @@ authors="RayTrace082"
 
 description='''Expanding on the natural world of Minecraft.'''
 
-[[dependencies.citadel]]
+[[dependencies.untamedwilds]]
     modId="citadel"
     mandatory=true
     versionRange="[1.6.0,)"


### PR DESCRIPTION
This change would show that "Mod untamedwilds requires Citadel 1.6.0 or above" instead of just saying it has loading errors.