### PR TITLE
Fix crash on performWorldGenSpawning

### DIFF
--- a/src/main/java/untamedwilds/entity/ComplexMob.java
+++ b/src/main/java/untamedwilds/entity/ComplexMob.java
@@ -217,6 +217,13 @@ public abstract class ComplexMob extends TamableAnimal {
 
     @SuppressWarnings("unchecked") // Don't use this outside ComplexMobs
     public <T extends ComplexMob> void breed() {
+        // Just return early if we're not the main server thread
+        // AKA don't allow WorldGen ForkJoin-created entities to breed entities (since they were added off-thread)
+        // This might be due to wantsToBreed() returning true as long as naturalBreeding is not explicitly disabled
+        if (!(this.level instanceof ServerLevel serverLevel) || !serverLevel.getServer().isSameThread()) {
+            return;
+        }
+
         int bound = 1 + (this.getOffspring() > 0 ? this.random.nextInt(this.getOffspring() + 1) : 0);
         for (int i = 0; i < bound; i++) {
             T child = (T) this.getBreedOffspring((ServerLevel) this.level, this);


### PR DESCRIPTION
```
at net.minecraft.server.level.ServerLevel.handler$chc000$cupboard$OnaddEntity(ServerLevel.java:1656) ~[server-1.20.1-20230612.114412-srg.jar%23543!/:?]
at net.minecraft.server.level.ServerLevel.m_8872_(ServerLevel.java) ~[server-1.20.1-20230612.114412-srg.jar%23543!/:?]
at net.minecraft.server.level.ServerLevel.m_7967_(ServerLevel.java:815) ~[server-1.20.1-20230612.114412-srg.jar%23543!/:?]
at untamedwilds.entity.ComplexMob.breed(ComplexMob.java:239) ~[untamedwilds-1.20.1-4.0.4.jar%23529!/:4.0.4]
at untamedwilds.entity.relict.EntitySpitter.updateAttributes(EntitySpitter.java:353) ~[untamedwilds-1.20.1-4.0.4.jar%23529!/:4.0.4]
at untamedwilds.entity.ComplexMob.m_6518_(ComplexMob.java:422) ~[untamedwilds-1.20.1-4.0.4.jar%23529!/:4.0.4]
at net.minecraftforge.event.ForgeEventFactory.handler$dgh000$blueprint$onFinalizeSpawn(ForgeEventFactory.java:1569) ~[forge-1.20.1-47.4.10-universal.jar%23548!/:?]
at net.minecraftforge.event.ForgeEventFactory.onFinalizeSpawn(ForgeEventFactory.java:285) ~[forge-1.20.1-47.4.10-universal.jar%23548!/:?]
at untamedwilds.world.FaunaSpawn.performWorldGenSpawning(FaunaSpawn.java:151) ~[untamedwilds-1.20.1-4.0.4.jar%23529!/:4.0.4]
```

performWorldGenSpawning() -> onFinalizeSpawn() -> EntitySpitter.updateAttributes() -> ComplexMob.breed()

WorldGen spawning causes some ComplexMob instances to breed (maybe due to wantsToBreed always returning true?), which is illegal when called from a worldGen thread

So we just return early on breed() if the caller isn't the server main thread, this fixes the crash but I'm unsure if any features are affected